### PR TITLE
Closing window minimizes to tray

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -233,6 +233,16 @@ app.on('change-site', () => {
   });
 });
 
+// Toggle showing and hiding the main window based on visibility.
+// (Designed to be called from clicking on the tray icon.)
+function toggleMinimizedToTray() {
+	if (mainWindow.isVisible()) {
+		minimizeToTray();
+	} else {
+		showFromTray();
+	}
+}
+
 function showFromTray() {
     if (mainWindow.isVisible()) {
       mainWindow.focus();
@@ -275,7 +285,7 @@ async function handleTray() {
       // Create tray menu items
       tray.setContextMenu(trayContextMenu(app))
       tray.on('click', () => {
-        tray.popUpContextMenu();
+        toggleMinimizedToTray();
       });
     }
   } catch (error) {


### PR DESCRIPTION
This enables standard "close to tray" behaviour.

If the tray icon is enabled, intercept the default main window close event in order to hide the application rather than closing the entire application. Selecting quit on the tray icon context menu will quit the application as normal.

Arguably should be an option in the configuation, but this is the basic behaviour.